### PR TITLE
💚 Remove npm publish provenance flag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,4 @@ jobs:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm i --frozen-lockfile
-      - run: pnpm publish --provenance --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: pnpm publish --no-git-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Note
+- Remove provenance flag and public access level from npm publish command.
+
 ## [2.1.0] 2026-02-10
 
 ### Added


### PR DESCRIPTION
Package is publish with provenance by default when having trusted publishing

REDMINE-100208